### PR TITLE
Fixed. Using a custom path while using system gems is unsupported.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - image: ruby:2.5-slim
     environment:
       SLACK_CHANNEL: "<< parameters.slack_channel >>"
+      BUNDLE_PATH__SYSTEM: "false"
     working_directory: ~/app
     steps:
       - checkout

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ image: ruby:2.5-slim
 variables:
   BUNDLE_CACHE: "vendor/bundle/"
   ENVIRONMENT:  "production"
+  BUNDLE_PATH__SYSTEM: "false"
 
 cache:
   untracked: true


### PR DESCRIPTION
https://circleci.com/gh/sue445/today_anime/242

```
+ bundle install --jobs=4 --retry=3 --path=vendor/bundle --gemfile=Gemfile --clean --without development
Using a custom path while using system gems is unsupported.

path:
Set for your local app (/usr/local/bundle/config): "vendor/bundle"

path.system:
Set via BUNDLE_PATH__SYSTEM: true

disable_shared_gems:
You have not configured a value for `disable_shared_gems`
```