### PR TITLE
Upgrade to ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: ruby:2.5-slim
+      - image: ruby:2.7-slim
     environment:
       SLACK_CHANNEL: "<< parameters.slack_channel >>"
       BUNDLE_PATH__SYSTEM: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:2.5-slim
+image: ruby:2.7-slim
 
 variables:
   BUNDLE_CACHE: "vendor/bundle/"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   syoboi_calendar
 
 BUNDLED WITH
-   1.17.3
+   2.2.14


### PR DESCRIPTION
I want to use ruby 3.0, but `slack-notifier` doesn't support ruby 3.0 yet...

https://github.com/stevenosloan/slack-notifier/issues/115