### PR TITLE
Upgrade to Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: ruby:2.7-slim
+      - image: ruby:3.0-slim
     environment:
       SLACK_CHANNEL: "<< parameters.slack_channel >>"
       BUNDLE_PATH__SYSTEM: "false"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: ruby:3.0-slim
+      - image: ruby:3.0
     environment:
       SLACK_CHANNEL: "<< parameters.slack_channel >>"
       BUNDLE_PATH__SYSTEM: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:3.0-slim
+image: ruby:3.0
 
 variables:
   BUNDLE_CACHE: "vendor/bundle/"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:2.7-slim
+image: ruby:3.0-slim
 
 variables:
   BUNDLE_CACHE: "vendor/bundle/"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "activesupport", require: "active_support/all"
-gem "slack-notifier"
+gem "slack-notifier", ">= 2.4.0"
 gem "syobocalite"
 gem "syoboi_calendar"
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "activesupport", require: "active_support/all"
+gem "libxml-ruby"
 gem "slack-notifier", ">= 2.4.0"
 gem "syobocalite"
 gem "syoboi_calendar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       faraday (~> 1.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    libxml-ruby (3.2.1)
     method_source (1.0.0)
     minitest (5.14.4)
     multi_xml (0.6.0)
@@ -51,6 +52,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  libxml-ruby
   pry-byebug
   slack-notifier (>= 2.4.0)
   syobocalite

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     ruby2_keywords (0.0.4)
-    slack-notifier (2.3.2)
+    slack-notifier (2.4.0)
     syobocalite (1.0.0)
       activesupport
       multi_xml
@@ -52,7 +52,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   pry-byebug
-  slack-notifier
+  slack-notifier (>= 2.4.0)
   syobocalite
   syoboi_calendar
 


### PR DESCRIPTION
slack-notifier supports Ruby 3.0 since v2.4.0

https://github.com/slack-notifier/slack-notifier/blob/main/changelog.md#240